### PR TITLE
fix: added rel property to links to cross origin destinations

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -239,6 +239,7 @@
             class="text-purple-400 hover:text-purple-300 mb-2"
             :href="url"
             target="_blank"
+            rel="noopener noreferrer"
           >
             <span class="sr-only">{{ name }}</span>
             <SvgIcon :icon-name="name" />


### PR DESCRIPTION
This closes issue #48

Before
![image](https://user-images.githubusercontent.com/21993984/127679535-9d219074-e8de-43c3-9952-bcae43cf40e2.png)

Now
![image](https://user-images.githubusercontent.com/21993984/127679569-4321e869-b141-4286-a0f9-ca635bf5dfe5.png)
